### PR TITLE
Improve Supabase setup for Smithery deployments

### DIFF
--- a/server/src/index-smithery-robust.ts
+++ b/server/src/index-smithery-robust.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import { Invoice, InvoiceSchema } from "./shared/types/invoice.js";
 import { generateInvoicePdfBuffer } from "./shared/components/invoice-template.js";
 import { z } from "zod";
-import { createClient } from '@supabase/supabase-js';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
 
 // ===== CONFIGURATION SCHEMA =====
 // This schema defines what configuration parameters users can provide
@@ -25,6 +25,7 @@ export const configSchema = z.object({
   // OPTIONAL: Storage settings (defaults work for most cases)
   storageBucket: z.string().default("invoices").describe("Supabase storage bucket name for PDFs (default: invoices)"),
   autoCreateBucket: z
+    .coerce
     .boolean()
     .default(false)
     .describe(
@@ -39,6 +40,7 @@ export const configSchema = z.object({
 
   // OPTIONAL: Legacy field preserved for backwards compatibility. Metadata storage is currently disabled.
   enableMetadataStorage: z
+    .coerce
     .boolean()
     .default(false)
     .describe(
@@ -50,7 +52,7 @@ export type Config = z.infer<typeof configSchema>;
 
 // ===== SUPABASE CLIENT MANAGEMENT =====
 class SupabaseManager {
-  private supabase: any;
+  private supabase: SupabaseClient;
   private config: Config;
 
   constructor(config: Config) {
@@ -129,7 +131,7 @@ class SupabaseManager {
 
       const { error } = await this.supabase.storage
         .from(this.config.storageBucket)
-        .list({ limit: 1, offset: 0 });
+        .list('', { limit: 1, offset: 0 });
 
       if (error) {
         if (error.message?.toLowerCase().includes('not found')) {

--- a/server/src/index-smithery-robust.ts
+++ b/server/src/index-smithery-robust.ts
@@ -67,6 +67,21 @@ class SupabaseManager {
 
   async initialize(): Promise<void> {
     try {
+      // Test storage connection (non-fatal) so users get early feedback about credentials
+      try {
+        const { data: buckets, error } = await this.supabase.storage.listBuckets();
+        if (error) {
+          console.warn('Storage connection test failed:', error.message);
+          // Don't throw error - storage might still work for uploads
+        } else {
+          console.log('✅ Supabase Storage connection verified');
+          console.log('📋 Available buckets:', buckets?.map((bucket: { name: string }) => bucket.name) || 'none');
+        }
+      } catch (storageError) {
+        console.warn('Storage connection test error:', storageError);
+        // Continue anyway - uploads might still work
+      }
+
       if (this.config.autoCreateBucket) {
         await this.ensureBucketExists();
       } else {
@@ -89,8 +104,6 @@ class SupabaseManager {
       if (error) {
         console.warn('Could not list buckets:', error.message);
         console.log('⚠️  Will attempt to create bucket anyway...');
-      } else {
-        console.log('📋 Available buckets:', buckets?.map((bucket: { name: string }) => bucket.name) || 'none');
       }
 
       const bucketExists = buckets?.some((bucket: { name: string }) => bucket.name === this.config.storageBucket);

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -29,7 +29,12 @@ startCommand:
         title: "Storage Bucket Name"
         description: "Supabase storage bucket name for PDF files (default: invoices)"
         default: "invoices"
-      
+      autoCreateBucket:
+        type: boolean
+        title: "Auto-create Storage Bucket"
+        description: "Requires a Supabase service role key. Disable when using an anon key (default: false)."
+        default: false
+
       # OPTIONAL: Business Information (for invoice branding)
       businessName:
         type: string
@@ -48,25 +53,19 @@ startCommand:
         type: string
         title: "Business Address"
         description: "Your business address (appears on invoices)"
-      
-      # OPTIONAL: Advanced Settings (usually keep defaults)
-      autoCreateBucket:
-        type: boolean
-        title: "Auto-create Storage Bucket"
-        description: "Auto-create bucket if missing (set false if bucket exists)"
-        default: false
+
       enableMetadataStorage:
         type: boolean
-        title: "Enable Database Storage"
-        description: "Store invoice metadata in database (set false for URL-only)"
+        title: "(Deprecated) Database Storage"
+        description: "Kept for backwards compatibility. Metadata storage is currently disabled and this flag is ignored."
         default: false
   exampleConfig:
     supabaseUrl: "https://mohsljimdduthwjhygkp.supabase.co"
     supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
     storageBucket: "invoices"
+    autoCreateBucket: false
     businessName: "My Business Ltd"
     businessEmail: "contact@mybusiness.com"
     businessPhone: "+44 123 456 7890"
     businessAddress: "123 Business St, London, UK"
-    autoCreateBucket: false
     enableMetadataStorage: false


### PR DESCRIPTION
## Summary
- add optional autoCreateBucket support that verifies bucket access without requiring service keys and improve Supabase upload errors
- expand environment configuration fallbacks and warn when deprecated metadata storage is requested
- refresh Smithery configuration and deployment docs to focus on Supabase-only storage expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0cbbd76c8324aced569bc587b929